### PR TITLE
Opacity range slider update while dragging

### DIFF
--- a/arrogance.js
+++ b/arrogance.js
@@ -399,7 +399,7 @@ $('#gridblocksize').change(function(e) { 
     drawBoard();
     return false;
 });
-$('#eraseropacity').change(function() {
+$('#eraseropacity').on('input change', function() {
     changeOpacity();
     draw();
 });


### PR DESCRIPTION
On `input` event adjusts the opacity while moving the range slider.

<img width="262" alt="Screen Shot 2021-10-13 at 9 50 13 PM" src="https://user-images.githubusercontent.com/6657634/137236944-b844e7f5-ed45-4007-9fde-9ccc89c0027a.png">
