### PR TITLE
Prevent truncated text in menu

### DIFF
--- a/arrogance.css
+++ b/arrogance.css
@@ -27,6 +27,13 @@ h1 {
     background: rgb(223, 117, 20); /* this is an orange */
 }
 .tool_down { cursor: crosshair; }
+input[type="file"] {
+    /* Truncate text in file input to fit menu */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
+}
 #modal {
     display: none;
     position: absolute;


### PR DESCRIPTION
Text is truncated at smaller viewport sizes due to weird file input behavior:
<img width="220" alt="Screen Shot 2021-10-13 at 9 57 32 PM" src="https://user-images.githubusercontent.com/6657634/137237690-49200e08-bc99-4065-92b4-07855726f0ee.png">

Fixed:
<img width="215" alt="Screen Shot 2021-10-13 at 9 58 39 PM" src="https://user-images.githubusercontent.com/6657634/137237750-f34e6110-74b3-4ecc-8c0d-44350ebbac8f.png">
