### PR TITLE
Drag to draw + proofread instructions

### DIFF
--- a/arrogance.css
+++ b/arrogance.css
@@ -10,6 +10,9 @@
     width: auto;
     height: auto;
 }
+#canvas:hover:active { 
+    cursor: crosshair;
+}
 #virtual {
     display: none;
 }
@@ -26,7 +29,6 @@ h1 {
 .pure-button-warning {
     background: rgb(223, 117, 20); /* this is an orange */
 }
-.tool_down { cursor: crosshair; }
 #modal {
     display: none;
     position: absolute;

--- a/arrogance.js
+++ b/arrogance.js
@@ -4,7 +4,6 @@ var prev_grid_block_size = 40;
 var grid_block_number_x = grid_width / grid_block_size;
 var grid_block_number_y = grid_width / grid_block_size;
 var current_opacity = 0.5;
-var tool_down = false;
 var background_img = new Image();
 var grid = [];
 var markers = [];
@@ -149,7 +148,7 @@ function getMousePos(e) {
 }
 
 function toggleGrid(e) {
-    if (!tool_down) {
+    if (e.type === 'mousemove' && e.buttons !== 1) {
         return;
     }
     var pos = getMousePos(e);
@@ -236,16 +235,6 @@ function changeImage() {
         }
         $('#modal').fadeOut();
     });
-}
-
-function toggleTool() {
-    if (!tool_down) {
-        tool_down = true;
-        $('#canvas').addClass('tool_down');
-    } else {
-        tool_down = false;
-        $('#canvas').removeClass('tool_down');
-    }
 }
 
 $('#canvas').bind('mousewheel DOMMouseScroll', function(e) {
@@ -403,13 +392,10 @@ $('#eraseropacity').change(function() {
     changeOpacity();
     draw();
 });
-$('#canvas').bind('mousemove', function(e) {
+$('#canvas').bind('click mousemove', function(e) {
     toggleGrid(e);
     drawGrid();
     drawMarkers();
-});
-$('#canvas').click(function() {
-    toggleTool();
 });
 $(document).keyup(function(e) {
     if (e.key == 'Backspace') {

--- a/index.php
+++ b/index.php
@@ -64,11 +64,10 @@ $url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http
             <a id="toolup" class="pure-button pure-button-secondary">↑</a> <a id="tooldown" class="pure-button pure-button-secondary">↓</a> Tool: <span id="tool">Tool</span><br><small>
                 <ul>
                     <li>Select a color tool.</li>
-                    <li>Left click on the map and start drawing the color onto the map.</li>
-                    <li>You can use your mouse wheel to change colors while drawing.</li>
-                    <li>Left click again to release the drawing tool.</li>
-                    <li>Right click to add a marker (e.g. cyclist/ped counts)</li>
-                    <li>Press backspace to remove a marker</li>
+                    <li>Click and drag to draw the color onto the map.</li>
+                    <li>Right click to add a marker (e.g. cyclist/ped counts.)</li>
+                    <li>Scroll or use your mouse wheel to cycle through colors.</li>
+                    <li>Press backspace to remove a marker.</li>
                 </ul></small>
         </div>
         <div class="l-box">


### PR DESCRIPTION
Instead of clicking to activate/de-activate the drawing tool, use dragging and clicking to draw.

This is more intuitive and works like most other drawing tools in other apps. It also prevents accidental drawing with a tool accidentally left activated (happened to me).